### PR TITLE
SR-1359: Uncomment restart iptables handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 PostgreSQL Master/Slave
 =========
 
-PostgreSQL 9.4 on one or two RHEL/Centos boxes.
+Preface
+------------
+Note: This is a fork off of bbaassssiiee.base_postgres role, from ansible galaxy
+https://github.com/bbaassssiiee/base_postgres/
+This role is used to ansibilize our SonarQube instance (sonarqube01.m.dfw.rtrdc.net/).
+We have forked it off to be stored in-house for a couple reasons:
+# There is a task that is commented out for some reason, `restart iptables`. This can cause the playbook to error out, since other tasks still invoke it.
+# It has been archived and migrated to dockpack.base_postgres
+# We also want to have more control over the configurations going forward
+------------
+
+PostgreSQL 9.6 on one or two RHEL/Centos boxes.
 
 Requirements
 ------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,6 +9,6 @@
   become: yes
   service: name=postgresql-{{ base_postgres_m }} state=restarted
 
-#- name: 'restart iptables'
-#  become: yes
-#  service: name=iptables state=restarted
+- name: 'restart iptables'
+ become: yes
+ service: name=iptables state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,5 +10,5 @@
   service: name=postgresql-{{ base_postgres_m }} state=restarted
 
 - name: 'restart iptables'
- become: yes
- service: name=iptables state=restarted
+  become: yes
+  service: name=iptables state=restarted


### PR DESCRIPTION
Part of [SR-1359: Migrate SQ ansible playbook over to new repo](https://renttherunway.jira.com/browse/SR-1359)

- Put this in its own repo so that we can pull+use it from another ansible repo we use for configuration management. 
- Simply put, uncomment the `restart iptables` handler so that its usable and idempotent for our SonarQube host
- This whole codebase is forked from an Ansible Galaxy role, that is now archived. Formerly, this was just a dependency of our `sonar` role, also by [bbaassssiiee](https://github.com/bbaassssiiee/sonar/). It was revealed after some time that the `restart iptables` needed to be commented out, but b/c the original galaxy role is archived (and is read-only now, preventing us from making a PR), we had to fork off our own and make the fix ourselves, for the time being. 